### PR TITLE
Bento release 4.0.0 feature gmb 182 sites page

### DIFF
--- a/src/bento/siteData.js
+++ b/src/bento/siteData.js
@@ -1,0 +1,74 @@
+import gql from 'graphql-tag';
+
+// --------------- Icons configuration --------------
+// Ideal size for programListingIcon is 100x100 px
+// Ideal size for externalLinkIcon is 16x16 px
+const programListingIcon = {
+  src: 'https://raw.githubusercontent.com/CBIIT/datacommons-assets/main/bento/images/icons/svgs/programIcon.svg',
+  alt: 'Bento program logo',
+};
+
+const externalLinkIcon = {
+  src: 'https://raw.githubusercontent.com/CBIIT/datacommons-assets/main/bento/images/icons/svgs/externalLinkIcon.svg',
+  alt: 'External link icon',
+};
+
+// --------------- Table configuration --------------
+const table = {
+  // Set 'display' to false to hide the table entirely
+  display: true,
+  // Table title
+  title: 'Sites',
+  // Field name for table data, need to be updated only when using a different GraphQL query
+  dataField: 'sitesInfo',
+  // Value must be one of the 'field' in columns
+  defaultSortField: 'site_id',
+  // 'asc' or 'desc'
+  defaultSortDirection: 'asc',
+  // Set 'selectableRows' to true to show the row selection
+  selectableRows: false,
+  // A maximum of 10 columns are allowed
+  columns: [
+    {
+      dataField: 'site_id',
+      header: 'Site ID',
+      link: '/site/{site_id}',
+      display: true
+    },
+    {
+      dataField: 'site_name',
+      header: 'Site Name',
+    },
+    {
+      dataField: 'site_address',
+      header: 'Address',
+    },
+    {
+      dataField: 'site_status',
+      header: 'Status',
+    },
+    {
+      dataField: 'num_subjects',
+      header: 'Associated Subjects',
+    },
+  ],
+};
+
+// --------------- GraphQL query - Retrieve site info --------------
+const GET_SITES_DATA_QUERY = gql`{
+  sitesInfo{
+    site_id
+    site_name
+    site_address
+    site_status
+    num_subjects
+}
+}
+ `;
+
+export {
+  programListingIcon,
+  externalLinkIcon,
+  table,
+  GET_SITES_DATA_QUERY,
+};

--- a/src/components/Layout/LayoutView.js
+++ b/src/components/Layout/LayoutView.js
@@ -14,6 +14,7 @@ import About from '../../pages/about/aboutController';
 import DataDictonary from '../../pages/dataDictionary/dataDictonaryController';
 import Programs from '../../pages/programs/programsController';
 import ProgramDetail from '../../pages/programDetail/programDetailController';
+import Sites from '../../pages/sites/sitesController';
 import GraphqlClient from '../GraphqlClient/GraphqlView';
 // import JBrowse from '../JBrowse/JBrowseView';
 import JBrowseDetail from '../../pages/jbrowseDetail/jbrowseDetailController';
@@ -72,6 +73,7 @@ const Layout = ({ classes, isSidebarOpened }) => {
 
             {/* SECTION: Member & Admin only Path */}
             <PrivateRoute path="/programs" access={['admin', 'member']} component={Programs} />
+            <PrivateRoute path="/sites" access={['admin', 'member']} component={Sites} />
             <PrivateRoute path="/fileCentricCart" access={['admin', 'member']} component={CarView} />
             <PrivateRoute path="/program/:id" access={['admin', 'member']} component={ProgramDetail} />
             <PrivateRoute path="/subject/:id" access={['admin', 'member']} component={CaseDetail} />

--- a/src/pages/sites/sitesController.js
+++ b/src/pages/sites/sitesController.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { useQuery } from '@apollo/client';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import View from './sitesView';
+import { Typography } from '../../components/Wrappers/Wrappers';
+import { GET_SITES_DATA_QUERY } from '../../bento/siteData';
+
+const container = () => {
+  const { loading, error, data } = useQuery(GET_SITES_DATA_QUERY);
+  if (loading) return <CircularProgress />;
+  if (error) return <Typography variant="headline" color="error" size="sm">{error ? `An error has occurred in loading stats component: ${error}` : 'Recieved wrong data'}</Typography>;
+  return <View data={data} />;
+};
+
+export default container;

--- a/src/pages/sites/sitesView.js
+++ b/src/pages/sites/sitesView.js
@@ -1,0 +1,152 @@
+import React from 'react';
+import {
+  Grid,
+  withStyles,
+} from '@material-ui/core';
+import {
+  CustomDataTable
+} from '@bento-core/data-table';
+import { getOptions, getColumns } from '@bento-core/util';
+import globalData from '../../bento/siteWideConfig';
+import {
+  table, programListingIcon, externalLinkIcon,
+} from '../../bento/siteData';
+import Stats from '../../components/Stats/AllStatsController';
+import { Typography } from '../../components/Wrappers/Wrappers';
+import { onClearAllAndSelectFacetValue } from '../dashTemplate/sideBar/BentoFilterUtils';
+
+const Sites = ({ classes, data }) => {
+  const redirectTo = (site) => onClearAllAndSelectFacetValue('registering_institution', site.rowData[1]);
+
+  return (
+    <>
+      <Stats />
+      <div className={classes.tableContainer}>
+        <div className={classes.container}>
+          <div className={classes.header}>
+            <div className={classes.logo}>
+              <img
+                src={programListingIcon.src}
+                alt={programListingIcon.alt}
+              />
+
+            </div>
+            <div className={classes.headerTitle}>
+              <div className={classes.headerMainTitle}>
+                <span>
+                  <Typography>
+                    <span className={classes.headerMainTitle}>{table.title}</span>
+                  </Typography>
+                </span>
+              </div>
+            </div>
+          </div>
+
+          { table.display ? (
+            <div id="table_sites" className={classes.tableDiv}>
+              <Grid container>
+                <Grid item xs={12}>
+                  <CustomDataTable
+                    data={data[table.dataField]}
+                    columns={getColumns(table, classes, data, externalLinkIcon, '/subjects', redirectTo, '', globalData.replaceEmptyValueWith)}
+                    options={getOptions(table, classes)}
+                  />
+                </Grid>
+              </Grid>
+            </div>
+          ) : ''}
+        </div>
+
+      </div>
+    </>
+  );
+};
+
+const styles = (theme) => ({
+
+  link: {
+    textDecoration: 'none',
+    fontWeight: 'bold',
+    color: theme.palette.text.link,
+    '&:hover': {
+      textDecoration: 'underline',
+    },
+  },
+  card: {
+    minHeight: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  container: {
+    margin: 'auto',
+    maxWidth: '1440px',
+    paddingLeft: '36px',
+    paddingRight: '36px',
+  },
+  paper: {
+    textAlign: 'center',
+  },
+  fakeToolbar: {
+    ...theme.mixins.toolbar,
+  },
+  root: {
+    fontFamily: '"Lato Regular","Open Sans", sans-serif',
+    fontSize: '9pt',
+    letterSpacing: '0.025em',
+    color: '#000',
+    background: '#eee',
+  },
+  header: {
+    background: '#eee',
+    paddingLeft: '20px',
+    paddingRight: '50px',
+    borderBottom: '#42779A 10px solid',
+    height: '128px',
+    paddingTop: '35px',
+  },
+  headerMainTitle: {
+    fontFamily: 'Lato',
+    letterSpacing: '0.025em',
+    color: '#274FA5',
+    fontSize: '24pt',
+    position: 'absolute',
+    marginTop: '16px',
+    lineHeight: '25px',
+    marginLeft: '-3px',
+  },
+
+  headerTitle: {
+    maxWidth: '1440px',
+    margin: 'auto',
+    float: 'left',
+    marginLeft: '90px',
+  },
+  logo: {
+    position: 'absolute',
+    float: 'left',
+    marginLeft: '-17px',
+    width: '100px',
+    filter: 'drop-shadow(-3px 2px 6px rgba(27,28,28,0.29))',
+  },
+  tableContainer: {
+    background: '#eee',
+    paddingBottom: '50px',
+  },
+  tableDiv: {
+    margin: 'auto',
+  },
+  tableCell6: {
+    width: '120px',
+  },
+  externalLinkIcon: {
+    width: '14.5px',
+    verticalAlign: 'sub',
+    marginLeft: '4px',
+    paddingBottom: '2px',
+  },
+  linkSpan: {
+    display: '-webkit-box',
+  },
+});
+
+export default withStyles(styles, { withTheme: true })(Sites);


### PR DESCRIPTION
## Description

Added the sites page, clicking on ID correctly links to the sites details page and clicking on the associated subjects correctly links to the subjects page with the appropriate filters.

Note: - Data needs to be visited, subjects have registering_institution value but does not point to the respective site node. So in the facets on the explore page we can see University of Washington have 18 subjects but in the sites page University of Washington has 0 associated subjects. This is an issue with the data.

Fixes #GMB-182

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?